### PR TITLE
cmake: Fix warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
+cmake_minimum_required(VERSION 3.10)
+
 project(FAT16)
-cmake_minimum_required(VERSION 3.2)
 
 option(BUILD_EXAMPLES "Build the examples project as well" OFF)
 


### PR DESCRIPTION
```
CMake Warning (dev) at CMakeLists.txt:1 (project):
  cmake_minimum_required() should be called prior to this top-level project()
  call.  Please see the cmake-commands(7) manual for usage documentation of
  both commands.
```

```
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```